### PR TITLE
Add device assembly and usage instructions

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,16 @@
-# Compiling and Flashing this Firmware
+## Compiling the Firmware
 
-## Setting up the Build Environment
+### Using Visual Studio Code
+
+> [!TIP]
+> All commands below can be typed directly into the **Command Palette** (`Ctrl+Shift+P`).
+
+1. **Raspberry Pi Pico: Import Pico Project**
+   - Click the `Change` button and select the `Firmware` folder.
+   - Click the `Import` button.
+2. **Raspberry Pi Pico: Compile Pico Project**
+
+### Without an IDE
 
 ### Install Pico SDK
 This project uses the [Pico SDK](https://github.com/raspberrypi/pico-sdk/tree/master).
@@ -18,20 +28,8 @@ PICO_SDK_PATH=/home/username/projects/pico-sdk
 ````
 On Linux, it may be preferrable to put this in your `.bashrc` file.
 
-## Compiling the Firmware
-
-### Using Visual Studio Code
-
-> [!TIP]
-> All commands below can be typed directly into the **Command Palette** (`Ctrl+Shift+P`).
-
-1. **Raspberry Pi Pico: Import Pico Project**
-   - Click the `Change` button and select the `Firmware` folder.
-   - Click the `Import` button.
-2. **Raspberry Pi Pico: Compile Pico Project**
-
-### Without an IDE
-From this directory, create a directory called build, enter it, and invoke cmake with:
+### Build
+From this directory, create a directory called `build`, enter it, and invoke `cmake` with:
 ````
 mkdir build
 cd build

--- a/Interface/Harp.Hobgoblin/README.md
+++ b/Interface/Harp.Hobgoblin/README.md
@@ -19,7 +19,7 @@ Console.WriteLine($"{deviceName} WhoAmI: {whoAmI} Timestamp (s): {timestamp}");
 
 ## Additional Documentation
 
-For additional documentation and examples, refer to the [official Harp documentation](https://harp-tech.org).
+For additional documentation and examples, refer to the [official Harp documentation](https://harp-tech.org/articles/operators.html).
 
 ## Feedback & Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ The Harp Hobgoblin is designed to operate directly from a [Raspberry Pi Pico](ht
     - [Gravity: 9 PCS Sensor Set for Arduino](https://www.dfrobot.com/product-110.html)
     - [Gravity: 27 PCS Sensor Set for Arduino](https://www.dfrobot.com/product-725.html)
 
+## Flashing the firmware
+
+1. Press-and-hold the Pico BOOTSEL button while you connect the device to the computer USB port.
+2. Drag-and-drop the `.uf2` file matching your Pico board into the new storage device that appears on your PC.
+
 ## Building the firmware
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ The Harp Hobgoblin is designed to operate directly from a [Raspberry Pi Pico](ht
 1. Press-and-hold the Pico BOOTSEL button while you connect the device to the computer USB port.
 2. Drag-and-drop the `.uf2` file matching your Pico board into the new storage device that appears on your PC.
 
+## Using the device
+
+Harp Hobgoblin is designed for use with the [Bonsai](https://bonsai-rx.org/) visual reactive programming language.
+
+1. Install the `Harp.Hobgoblin` package using the [Bonsai package manager](https://bonsai-rx.org/docs/articles/packages.html).
+2. Insert the `Device` source from the editor toolbox.
+3. For additional documentation and examples, refer to the [official Harp documentation](https://harp-tech.org/articles/operators.html).
+
 ## Building the firmware
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A simple multi-purpose device for learning the basics of the Harp standard. Although the repository contains working device metadata, firmware and high-level interface, the Harp Hobgoblin device is made to be adapted and modified for a variety of purposes.
 
+## Assembling the device
+
+The Harp Hobgoblin is designed to operate directly from a [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/) / [Pico 2](https://www.raspberrypi.com/products/raspberry-pi-pico-2/) board. To make it easier to interface with a variety of inputs and outputs we recommend the [Gravity: Expansion Board](https://www.dfrobot.com/product-2393.html).
+
+> [!NOTE]
+> The following links are provided as a reference only. We are not connected to or in any other way affiliated with the suppliers listed below.
+
+  - Raspberry Pi Pico:
+    - [Raspberry Pi Pico (with headers)](https://thepihut.com/products/raspberry-pi-pico?src=raspberrypi&variant=41925332566211)
+    - [Raspberry Pi Pico 2 (with headers)](https://thepihut.com/products/raspberry-pi-pico-2?variant=54063366701441)
+  - Gravity Sensors:
+    - [Gravity: Expansion Board for Raspberry Pi Pico / Pico 2](https://www.dfrobot.com/product-2393.html)
+    - [Gravity: 9 PCS Sensor Set for Arduino](https://www.dfrobot.com/product-110.html)
+    - [Gravity: 27 PCS Sensor Set for Arduino](https://www.dfrobot.com/product-725.html)
+
 ## Building the firmware
 
 ### Prerequisites


### PR DESCRIPTION
To make it easier to adopt and use the board we reorganize the README to prioritize assembling and flashing the device, as well as including short instructions on how to use it.

Fixes #11 