### PR TITLE
Avoid sending ADC events in timer callback

### DIFF
--- a/Interface/Harp.Hobgoblin/Harp.Hobgoblin.csproj
+++ b/Interface/Harp.Hobgoblin/Harp.Hobgoblin.csproj
@@ -16,7 +16,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
To prevent concurrency when sending event messages, we store sampled analog data and corresponding timestamp in a queue accessed only during the main update loop.